### PR TITLE
Revert "Bump django-unfold from 0.46.0 to 0.57.0 in /src"

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 Django==4.2.21
 django-health-check==3.18.3
-django-unfold==0.57.0
+django-unfold==0.46.0
 psycopg[binary]>=3.1
 gunicorn==23.0.0
 mozilla-django-oidc>=2.0.0


### PR DESCRIPTION
Reverts MBcom/kioskmanager#3
* due to unfold issue when modifying login screen